### PR TITLE
New simple_tag

### DIFF
--- a/lib/markdown_deux/templatetags/markdown_deux_tags.py
+++ b/lib/markdown_deux/templatetags/markdown_deux_tags.py
@@ -76,3 +76,8 @@ def markdown_allowed():
         % settings.MARKDOWN_DEUX_HELP_URL)
 
 
+@register.simple_tag
+def markdown_ok():
+    """Ultra brief indication that Markdown is available, for cramped UIs"""
+    return ('Use <a href="%s" target="_blank">Markdown</a>!'
+        % settings.MARKDOWN_DEUX_HELP_URL)


### PR DESCRIPTION
New tag markdown_ok provides an ultra brief indication that Markdown is available, for cramped UIs.
I'm finding the markdown_allowed tag frequently spills outside of field label areas etc.
